### PR TITLE
Fix for building pulse-audio with SysV init.

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -9,7 +9,6 @@ SRC_URI += " \
 
 FILES_${PN} += "${sysconfdir}/systemd/system/*"
 
-#DEPENDS_append = " update-rc.d-native"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','systemd','','update-rc.d-native',d)}"
 
 do_install_append() {

--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -9,6 +9,8 @@ SRC_URI += " \
 
 FILES_${PN} += "${sysconfdir}/systemd/system/*"
 
+DEPENDS_append = " update-rc.d-native"
+
 do_install_append() {
 	install -d ${D}/${sysconfdir}/dbus-1/system.d
 	install -d ${D}/${sysconfdir}/pulse

--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -9,7 +9,8 @@ SRC_URI += " \
 
 FILES_${PN} += "${sysconfdir}/systemd/system/*"
 
-DEPENDS_append = " update-rc.d-native"
+#DEPENDS_append = " update-rc.d-native"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES','systemd','','update-rc.d-native',d)}"
 
 do_install_append() {
 	install -d ${D}/${sysconfdir}/dbus-1/system.d


### PR DESCRIPTION
pulseaudio fails to build when using SysV init instead of systemd. bitbake tries to use the host native update-rc.d instead of the one from the bitbake sysroot.